### PR TITLE
Fix FTBS with gcc 8

### DIFF
--- a/src/spectr.c
+++ b/src/spectr.c
@@ -31,6 +31,9 @@
 # define creal(XX) std::real(XX)
 # define cimag(XX) std::imag(XX)
 # define _I ((complex_t)(1i))
+  #ifdef __cpp_lib_complex_udls
+    using namespace std::literals::complex_literals;
+  #endif
   typedef std::complex<double> complex_t;
 #else
 # include <complex.h>


### PR DESCRIPTION
complex operator""i are declared in the namespace std::literals::complex_literals

Somehow gcc 8 is less permissive than gcc 7