### PR TITLE
Limit time spent planning fft.

### DIFF
--- a/src/fft.c
+++ b/src/fft.c
@@ -231,7 +231,9 @@ fftx_init (struct FFTAnalysis* ft, uint32_t window_size, double rate, double fps
 	fftx_reset (ft);
 
 	pthread_mutex_lock (&fftw_planner_lock);
+	fftwf_set_timelimit(2.0);  // spend no more than 2 seconds generating fft plan.
 	ft->fftplan = fftwf_plan_r2r_1d (window_size, ft->fft_in, ft->fft_out, FFTW_R2HC, FFTW_MEASURE);
+	fftwf_set_timelimit(FFTW_NO_TIMELIMIT); // restore to default.
 	++instance_count;
 	pthread_mutex_unlock (&fftw_planner_lock);
 }


### PR DESCRIPTION
Fix for issue 15: Long starting time in RPi 

The problem (as reporrted in the issue): fftw spends about 15 seconds building a plan for the fft on Raspberry Pi which tends to block the UI of host applications. (Loading and Activation, although not performed on an RT thread, are not generally expected to such a long time). 

This pull request adds a call to limit the time spent planning the fft to no more than 2 seconds.

There are two possible solutions: either change the flag passed to `fftwf_plan_r2r_1d`  from `FFTW_MEASURE` to `FFTW_ESTIMATE`; or ask fftw to limit the time spent planning with a call to `fftwf_set_timelimit`. 

I have tested both options on Raspberry Pi. Neither seems to significantly affect FFT execution time. An FFT of only 8k samples doesn't really need elaborate planning, as it's not large enough  to significantly benefit from plan changes that provide cache optimizations. All three options (the original code, the `FFTW_ESTIMATE`, and `fftwf_set_timelimit` each use about 30% of available CPU time on a raspberry pi. 

The CPU use is ... rather alarmingly high. A future enhancement might be to push processing to a worker thread, and maybe subsample a bit.






