### PR TITLE
Include Tuna in plugin display names

### DIFF
--- a/lv2ttl/tuna.lv2.ttl.in
+++ b/lv2ttl/tuna.lv2.ttl.in
@@ -4,7 +4,7 @@
   a lv2:Plugin, doap:Project, lv2:AnalyserPlugin;
   doap:license <http://usefulinc.com/doap/licenses/gpl> ;
   doap:maintainer <http://gareus.org/rgareus#me> ;
-  doap:name "x42 Instrument Tuner@NAME_SUFFIX@";
+  doap:name "x42 Tuna Instrument Tuner@NAME_SUFFIX@";
   @VERSION@
   @UITTL@
   @MODBRAND@

--- a/lv2ttl/tuna.ttl.in
+++ b/lv2ttl/tuna.ttl.in
@@ -27,6 +27,6 @@ idpy:interface a lv2:ExtensionData .
 <http://gareus.org/oss/lv2/@LV2NAME@>
 	a doap:Project;
 	doap:maintainer <http://gareus.org/rgareus#me> ;
-	doap:name "x42 Instrument Tuner" .
+	doap:name "x42 Tuna Instrument Tuner" .
 
 

--- a/lv2ttl/tuna1.h
+++ b/lv2ttl/tuna1.h
@@ -9,7 +9,7 @@ static const RtkLv2Description _plugin_tuna_one = {
 	&lv2ui_descriptor
 	, 0 // uint32_t dsp_descriptor_id
 	, 0 // uint32_t gui_descriptor_id
-	, "x42 Instrument Tuner" // const char *plugin_human_id
+	, "x42 Tuna Instrument Tuner" // const char *plugin_human_id
 	, (const struct LV2Port[20])
 	{
 		{ "control", ATOM_IN, nan, nan, nan, "GUI to plugin communication"},

--- a/lv2ttl/tuna2.h
+++ b/lv2ttl/tuna2.h
@@ -9,7 +9,7 @@ static const RtkLv2Description _plugin_tuna_two = {
 	&lv2ui_descriptor
 	, 1 // uint32_t dsp_descriptor_id
 	, 0 // uint32_t gui_descriptor_id
-	, "x42 Instrument Tuner[Spectrum]" // const char *plugin_human_id
+	, "x42 Tuna Instrument Tuner[Spectrum]" // const char *plugin_human_id
 	, (const struct LV2Port[20])
 	{
 		{ "control", ATOM_IN, nan, nan, nan, "GUI to plugin communication"},


### PR DESCRIPTION
Fixes #5.

Include `Tuna` in the LV2 project and both plugin instance display names so hosts that search only `doap:name` can find the plugin by its project name. Update the checked-in runtime descriptor headers to keep the standalone/plugin collection labels synchronized with the generated TTL.

Resulting names:
- `x42 Tuna Instrument Tuner`
- `x42 Tuna Instrument Tuner[Spectrum]`

Validation:
- Full LV2 DSP and OpenGL UI build passes in a clean dependency image.
- Generated `build/tuna.ttl` contains Tuna in all three project/instance `doap:name` values.
- BCL verifies both generated metadata variants and the corresponding compiled descriptor names.
- All 79 Broadcast Control Lab infrastructure tests pass.
- `git diff --check` passes.

BCL case: https://github.com/iibaranov-IG/broadcast-control-lab/tree/main/cases/tuna-5
